### PR TITLE
feat(): update the logic when user add new field to the tree and the parent is node is collapse, we need to open the parent

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,13 +7,12 @@ function App() {
   return (
     <>
     <JsonEditorV2 value={{
-        arr: new Array(12).fill(0),
         object: {
             x: 1,
             y: 'sadasd',
             z: true,
-            nested1: {}
-        }
+        },
+        arr: new Array(12).fill(0)
     } } onValueChange={console.log} />
     </>
   )

--- a/src/jsonEditor/types.ts
+++ b/src/jsonEditor/types.ts
@@ -60,6 +60,11 @@ export type UpdateNodeTypeEventType = {
 
 export type ToggleNodeType = {
   __custom_key__: VirtualTreeType['__custom_key__'],
+  /**
+   * @description
+   * Useful when we want to run toggle node, with specific state, for example open.
+   */
+  forceState?: boolean
 }
 
 

--- a/src/jsonEditorV2/virtualJsonTree.ts
+++ b/src/jsonEditorV2/virtualJsonTree.ts
@@ -216,12 +216,12 @@ export class VirtualJsonTree {
             if (current.__parent_key__ === params.__custom_key__) {
                 this.virtualTree[current.__custom_key__] = {
                     ...this.virtualTree[current.__custom_key__],
-                    __visible__: !current.__visible__
+                    __visible__: params.forceState ?? !current.__visible__
                 }
             } else if (params.__custom_key__ === current.__custom_key__) {
                 this.virtualTree[current.__custom_key__] = {
                     ...this.virtualTree[current.__custom_key__],
-                    __show_children__: !current.__show_children__
+                    __show_children__: params.forceState ?? !current.__show_children__
                 }
             }
         })
@@ -346,6 +346,18 @@ export class VirtualJsonTree {
                 },
                 addNewNodeForObj: (params: {value: unknown }): void => {
                     const { key, parentKey} = this.getItemPaths(item)
+                    /**
+                     * @description
+                     * If the parent node is close, open the parent node and then insert the new node to the tree.
+                     * this will help us show the new node when user click on add new field when the node is collapse.
+                     */
+                    const parent = this.virtualTree[parentKey as string]
+                    if (!parent.__show_children__) {
+                        this.toggleNode({
+                            __custom_key__: parentKey as string,
+                            forceState: true
+                        })
+                    }
                     this.addNewNode({
                         key,
                         value: params.value,


### PR DESCRIPTION
Update the logic when user add new field to the tree and the parent is node is collapse, we need to open the parent

- Add `forceState` for the toggle function.
- Open the parent node of collapse before adding the new field.

https://github.com/omriLugasi/rhino-tools-simple-json-editor/issues/10